### PR TITLE
Added the 'cypress-axe' plugin for cypress.  

### DIFF
--- a/website/cypress/integration/main.spec.js
+++ b/website/cypress/integration/main.spec.js
@@ -12,11 +12,13 @@ describe('Main', function () {
     cy.fixture('lambda_search_results.json').as('lambda_search_results')
 
     cy.visit('/')
+    cy.injectAxe()
   })
 
   it('loads the main page', function () {
     cy.title().should('eq', 'qit: Tech podcasts by topic')
     cy.get('input').should('have.attr', 'placeholder', 'Search for a great podcast here!')
+    cy.checkA11y()
   })
 
   it('can perform a search via the form', function () {

--- a/website/cypress/support/index.js
+++ b/website/cypress/support/index.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import 'cypress-axe'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -897,6 +897,12 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axe-core": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.3.2.tgz",
+      "integrity": "sha512-lRdxsRt7yNhqpcXQk1ao1BL73OZDzmFCWOG0mC4tGR/r14ohH2payjHwCMQjHGbBKm924eDlmG7utAGHiX/A6g==",
+      "dev": true
+    },
     "axobject-query": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
@@ -3609,6 +3615,12 @@
           }
         }
       }
+    },
+    "cypress-axe": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.5.1.tgz",
+      "integrity": "sha512-oj+diADUnnjmiT7635kQuaDx7MG4nMk64oWCuDEIbWpe7Q3v+FzBE3ou8pg346LagGyqDFv8r7GYt6JWve6+Vg==",
+      "dev": true
     },
     "d": {
       "version": "1.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,9 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.1.1",
+    "axe-core": "^3.3.2",
     "cypress": "^3.4.1",
+    "cypress-axe": "^0.5.1",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "jest": "^23.1.0",


### PR DESCRIPTION
This allows axe a11y testing to be done during cypress tests. After the test visits the page you wish to test, call 'cy.injectAxe()', then call 'cy.checkA11y()' to perform the test.  Errors will output to the console.  I only added it to run on the default main page but most (all) pages have at least one a11y error on them.